### PR TITLE
Fix typo in #ifdef PARALLEL

### DIFF
--- a/1010.c
+++ b/1010.c
@@ -357,7 +357,7 @@ typedef struct {
   t7_t field;        // initial then final field
 } move_t;
 
-#ifdef PARAELLEL
+#ifdef PARALLEL
 static int partial = PARALLEL_DEGREE;
 #else
 #define partial 1


### PR DESCRIPTION
I'm actually surprised this didn't get caught sooner.
With this typo in place, the parallelism defaults to 1, right?